### PR TITLE
sprockets-coffee-react integration

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -34,6 +34,7 @@ gem "sass-rails", "~> 4.0.3"
 gem "coffee-rails", "~> 4.0.0"
 gem "jquery-rails"
 gem "therubyracer", platforms: [:ruby]
+gem "sprockets-coffee-react"
 
 # error reporting
 gem "airbrake"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -76,6 +76,8 @@ GEM
     coffee-rails (4.0.1)
       coffee-script (>= 2.2.0)
       railties (>= 4.0.0, < 5.0)
+    coffee-react (2.1.0)
+      execjs
     coffee-script (2.3.0)
       coffee-script-source
       execjs
@@ -206,6 +208,11 @@ GEM
       multi_json (~> 1.0)
       rack (~> 1.0)
       tilt (~> 1.1, != 1.3.0)
+    sprockets-coffee-react (2.1.0)
+      coffee-react (>= 2.1.0)
+      coffee-script
+      sprockets
+      tilt
     sprockets-rails (2.2.0)
       actionpack (>= 3.0)
       activesupport (>= 3.0)
@@ -284,6 +291,7 @@ DEPENDENCIES
   sdoc (~> 0.4.0)
   slim-rails
   spring
+  sprockets-coffee-react
   therubyracer
   turbolinks
   uglifier (>= 1.3.0)

--- a/app/assets/javascripts/components/announcers_feed.js.cjsx
+++ b/app/assets/javascripts/components/announcers_feed.js.cjsx
@@ -1,9 +1,9 @@
 cx = React.addons.classSet
 exports = exports ? this
-exports.GameNotes = React.createClass
+exports.AnnouncersFeed = React.createClass
   componentDidMount: () ->
     $dom = $(this.getDOMNode())
   getInitialState: () ->
     exports.wftda.functions.camelize(this.props)
   render: () ->
-    `<div className="global-bout-notes"></div>`
+    <div className="announcers-feed"></div>

--- a/app/assets/javascripts/components/game.js.cjsx
+++ b/app/assets/javascripts/components/game.js.cjsx
@@ -23,7 +23,7 @@ exports.Game = React.createClass
     penaltyWhiteboard   = React.createElement(PenaltyWhiteboard, this.state)
     announcersFeed      = React.createElement(AnnouncersFeed, this.state)
     gameNotes           = React.createElement(GameNotes, this.state)
-    `<div className="game" data-tab={this.state.tab}>
+    <div className="game" data-tab={this.state.tab}>
       <header>
         <div className="container-fluid">
           <Titlebar />
@@ -49,4 +49,4 @@ exports.Game = React.createClass
         {announcersFeed}
         {gameNotes}
       </div>
-    </div>`
+    </div>

--- a/app/assets/javascripts/components/game_notes.js.cjsx
+++ b/app/assets/javascripts/components/game_notes.js.cjsx
@@ -1,9 +1,9 @@
 cx = React.addons.classSet
 exports = exports ? this
-exports.AnnouncersFeed = React.createClass
+exports.GameNotes = React.createClass
   componentDidMount: () ->
     $dom = $(this.getDOMNode())
   getInitialState: () ->
     exports.wftda.functions.camelize(this.props)
   render: () ->
-    `<div className="announcers-feed"></div>`
+    <div className="global-bout-notes"></div>

--- a/app/assets/javascripts/components/jam_timer.js.cjsx
+++ b/app/assets/javascripts/components/jam_timer.js.cjsx
@@ -417,7 +417,7 @@ exports.JamTimer = React.createClass
       'bar': true
       'active': this.state.awayAttributes.isTakingTimeout && this.state.awayAttributes.timeouts == 0
       'inactive': this.state.awayAttributes.timeouts < 1
-    `<div className="jam-timer">
+    <div className="jam-timer">
         <div className="row text-center">
           <div className="col-md-2 col-xs-2">
             <div className="timeout-bars home">
@@ -548,4 +548,4 @@ exports.JamTimer = React.createClass
             </button>
           </div>
         </div>
-    </div>`
+    </div>

--- a/app/assets/javascripts/components/lineup_tracker.js.cjsx
+++ b/app/assets/javascripts/components/lineup_tracker.js.cjsx
@@ -37,7 +37,7 @@ exports.LineupTracker = React.createClass
       'away': true
       'hidden-xs': !this.state.awayAttributes.isSelected
 
-    `<div className="lineup-tracker">
+    <div className="lineup-tracker">
       <div className="row teams text-center gutters-xs">
         <div className="col-sm-6 col-xs-6">
           <div className="boxed-good team-name" style={this.state.awayAttributes.colorBarStyle} onClick={this.handleToggleTeam}>
@@ -284,4 +284,4 @@ exports.LineupTracker = React.createClass
           </div>
         </div>
       </div>
-    </div>`
+    </div>

--- a/app/assets/javascripts/components/navbar.js.cjsx
+++ b/app/assets/javascripts/components/navbar.js.cjsx
@@ -32,7 +32,7 @@ exports.Navbar = React.createClass
       'active': this.state.tab == "penalty_whiteboard"
     announcersFeedCS = cx
       'active': this.state.tab == "announcers_feed"
-    `<div className="navbar">
+    <div className="navbar">
       <div className="container">
         <div className="row">
           <div className="col-xs-12 col-sm-12">
@@ -89,4 +89,4 @@ exports.Navbar = React.createClass
           </div>
         </div>
       </div>
-    </div>`
+    </div>

--- a/app/assets/javascripts/components/penalty_box_timer.js.cjsx
+++ b/app/assets/javascripts/components/penalty_box_timer.js.cjsx
@@ -6,4 +6,4 @@ exports.PenaltyBoxTimer = React.createClass
   getInitialState: () ->
     exports.wftda.functions.camelize(this.props)
   render: () ->
-    `<div className="penalty-box-timer"></div>`
+    <div className="penalty-box-timer"></div>

--- a/app/assets/javascripts/components/penalty_tracker.js.cjsx
+++ b/app/assets/javascripts/components/penalty_tracker.js.cjsx
@@ -6,4 +6,4 @@ exports.PenaltyTracker = React.createClass
   getInitialState: () ->
     exports.wftda.functions.camelize(this.props)
   render: () ->
-    `<div className="penalty-tracker"></div>`
+    <div className="penalty-tracker"></div>

--- a/app/assets/javascripts/components/penalty_whiteboard.js.cjsx
+++ b/app/assets/javascripts/components/penalty_whiteboard.js.cjsx
@@ -6,4 +6,4 @@ exports.PenaltyWhiteboard = React.createClass
   getInitialState: () ->
     exports.wftda.functions.camelize(this.props)
   render: () ->
-    `<div className="penalty-whiteboard"></div>`
+    <div className="penalty-whiteboard"></div>

--- a/app/assets/javascripts/components/scoreboard.js.cjsx
+++ b/app/assets/javascripts/components/scoreboard.js.cjsx
@@ -108,7 +108,7 @@ exports.Scoreboard = React.createClass
       'glyphicon': true
       'glyphicon-star': true
       'hidden': !this.props.homeAttributes.jammerAttributes.isLead
-    `<div className="scoreboard" id="scoreboard">
+    <div className="scoreboard" id="scoreboard">
       <section className="team home">
         <div className="logo">
           <img src={this.props.homeAttributes.logo} />
@@ -198,4 +198,4 @@ exports.Scoreboard = React.createClass
       </section>
       <section className={adsCS}></section>
       <section className={flyinsCS}></section>
-    </div>`
+    </div>

--- a/app/assets/javascripts/components/scorekeeper.js.cjsx
+++ b/app/assets/javascripts/components/scorekeeper.js.cjsx
@@ -32,7 +32,7 @@ exports.Scorekeeper = React.createClass
       'away': true
       'hidden-xs': !this.state.awayAttributes.isSelected
 
-    `<div className="scorekeeper">
+    <div className="scorekeeper">
       <div className="row teams text-center gutters-xs">
         <div className="col-sm-6 col-xs-6">
           <div className="team-name" style={this.state.awayAttributes.colorBarStyle} onClick={this.handleToggleTeam}>
@@ -191,4 +191,4 @@ exports.Scorekeeper = React.createClass
           <PassesList passes={this.state.homeAttributes.passStates} teamType="home" />
         </div>
       </div>
-    </div>`
+    </div>

--- a/app/assets/javascripts/components/scorekeeper/jam_item.js.cjsx
+++ b/app/assets/javascripts/components/scorekeeper/jam_item.js.cjsx
@@ -8,7 +8,7 @@ exports.JamItem = React.createClass
     jqNodeId = "##{nodeId}"
 
     return(
-      `<div className="row gutters-xs" id={nodeId} onClick={this.handleJamSelection}>
+      <div className="row gutters-xs" id={nodeId} onClick={this.handleJamSelection}>
         <div className="col-sm-2 col-xs-2">
           <div className="jam text-center">
             {this.props.number}
@@ -39,5 +39,5 @@ exports.JamItem = React.createClass
             10
           </div>
         </div>
-      </div>`
+      </div>
     )

--- a/app/assets/javascripts/components/scorekeeper/jams_list.js.cjsx
+++ b/app/assets/javascripts/components/scorekeeper/jams_list.js.cjsx
@@ -7,7 +7,7 @@ exports.JamsList = React.createClass
       JamItemFactory({key: this.props.jamNumber, number: this.props.jamNumber, skater: this.props.jammerAttributes.number, teamType: this.props.teamType})
     jamComponents.push(JamItemFactory({key: "0", number: this.props.jams.length+1, skater: "Skater", teamType: this.props.teamType}))
     return(
-      `<div className="jams">
+      <div className="jams">
         <div className="headers">
           <div className="row gutters-xs">
             <div className="col-sm-2 col-xs-2">
@@ -28,5 +28,5 @@ exports.JamsList = React.createClass
           {jamComponents}
         </div>
       </div>
-      `
+      
     )

--- a/app/assets/javascripts/components/scorekeeper/pass_edit_panel.js.cjsx
+++ b/app/assets/javascripts/components/scorekeeper/pass_edit_panel.js.cjsx
@@ -3,7 +3,7 @@ exports.PassEditPanel = React.createClass
   render: () ->
     if this.props.pass.passNumber == 1
       return(
-        `<div className="panel">
+        <div className="panel">
           <div className="edit-pass first-pass collapse" id={this.props.editPassId}>
             <div className="row gutters-xs">
               <div className="col-sm-2 col-xs-2 col-sm-offset-1 col-xs-offset-1">
@@ -50,11 +50,11 @@ exports.PassEditPanel = React.createClass
               </div>
             </div>
           </div>
-        </div>`
+        </div>
       )
     else
       return(
-        `<div className="panel">
+        <div className="panel">
           <div className="edit-pass second-pass collapse" id={this.props.editPassId}>
             <div className="row gutters-xs">
               <div className="col-sm-2 col-xs-2 col-sm-offset-1 col-xs-offset-1">
@@ -121,5 +121,5 @@ exports.PassEditPanel = React.createClass
               </div>
             </div>
           </div>
-        </div>`
+        </div>
       )

--- a/app/assets/javascripts/components/scorekeeper/pass_item.js.cjsx
+++ b/app/assets/javascripts/components/scorekeeper/pass_item.js.cjsx
@@ -10,7 +10,7 @@ exports.PassItem = React.createClass
     editPassId = "#{this.props.teamType}-team-edit-pass-#{this.props.pass.passNumber}"
     jqEditPassId = "##{editPassId}"
 
-    `<div aria-multiselectable="true" id={nodeId}>
+    <div aria-multiselectable="true" id={nodeId}>
       <div className="columns">
         <div className="row gutters-xs">
           <div className="col-sm-2 col-xs-2">
@@ -72,4 +72,4 @@ exports.PassItem = React.createClass
         </div>
       </div>
       <PassEditPanel pass={this.props.pass} teamType={this.props.teamType} editPassId={editPassId}/>
-    </div>`
+    </div>

--- a/app/assets/javascripts/components/scorekeeper/passes_list.js.cjsx
+++ b/app/assets/javascripts/components/scorekeeper/passes_list.js.cjsx
@@ -5,7 +5,7 @@ exports.PassesList = React.createClass
     passComponents = this.props.passes.map (pass) =>
       PassItemFactory({pass: pass, key: pass.number, teamType: this.props.teamType})
 
-    `<div className="passes">
+    <div className="passes">
       <div className="headers">
         <div className="row gutters-xs">
           <div className="col-sm-2 col-xs-2">
@@ -25,4 +25,4 @@ exports.PassesList = React.createClass
         </div>
       </div>
       {passComponents}
-    </div>`
+    </div>

--- a/app/assets/javascripts/components/titlebar.js.cjsx
+++ b/app/assets/javascripts/components/titlebar.js.cjsx
@@ -6,7 +6,7 @@ exports.Titlebar = React.createClass
   getInitialState: () ->
     exports.wftda.functions.camelize(this.props)
   render: () ->
-    `<div className="title-bar">
+    <div className="title-bar">
       <div className="container">
         <div className="row">
           <div className="col-xs-12 col-sm-12">
@@ -24,4 +24,4 @@ exports.Titlebar = React.createClass
           </div>
         </div>
       </div>
-    </div>`
+    </div>


### PR DESCRIPTION
Using backticks to escape XML in coffee files for JSX is pretty annoying. It messes with text editors' ability to do effective syntax highlighting, spacing, etc, and requires that inline code in the XML as denoted by curly brackets be in js instead of coffee, so you wind up with things like

```
`{collection.map(function(item){
    return(
        <strong>{item}</strong>
    )
 })}`
```

inside `.coffee` files.

This PR replaces existing `.js.jsx.coffee` files with corresponding `.js.cjsx` file that use [CJSX](https://github.com/jsdf/coffee-react-transform) for JSX-like syntax directly in CoffeeScript, and uses [sprockets-coffee-rails](https://github.com/jsdf/sprockets-coffee-react) to serve the `js.cjsx` assets from rails. The [sublime-react](https://github.com/reactjs/sublime-react) plugin has support for CJSX syntax highlighting and snippets.
