### PR TITLE
set star pass in pass edit

### DIFF
--- a/app/scripts/components/scoreboard.cjsx
+++ b/app/scripts/components/scoreboard.cjsx
@@ -112,11 +112,11 @@ module.exports = React.createClass
     awayJammerLeadCS = cx
       'glyphicon': true
       'glyphicon-star': true
-      'hidden': not awayJam? or not awayJam.getPasses()[0]? or not awayJam.getPasses()[0].lead or awayJam.getPasses().some (pass) -> pass.lostLead?
+      'hidden': not awayJam? or not awayJam.passes[0]? or not awayJam.passes[0].lead or awayJam.passes.some (pass) -> pass.lostLead?
     homeJammerLeadCS = cx
       'glyphicon': true
       'glyphicon-star': true
-      'hidden': not homeJam? or not homeJam.getPasses()[0]? or not homeJam.getPasses()[0].lead or homeJam.getPasses().some (pass) -> pass.lostLead?
+      'hidden': not homeJam? or not homeJam.passes[0]? or not homeJam.passes[0].lead or homeJam.passes.some (pass) -> pass.lostLead?
     <div className="scoreboard" id="scoreboard">
       <section className="team home">
         <div className="logo">

--- a/app/scripts/components/scorekeeper/jam_details.cjsx
+++ b/app/scripts/components/scorekeeper/jam_details.cjsx
@@ -9,11 +9,6 @@ module.exports = React.createClass
     mainMenuHandler: React.PropTypes.func
     prevJamHandler: React.PropTypes.func
     nextJamHandler: React.PropTypes.func
-  totalPoints: () ->
-    points = 0
-    @props.jam.getPasses().map (pass) =>
-      points += pass.points ? 0
-    return points
   render: () ->
     <div className="jam-details-container">
       <div className="links">
@@ -44,7 +39,7 @@ module.exports = React.createClass
           </div>
           <div className="col-sm-3 col-xs-3 text-right">
             <div className="jam-total-score">
-              <strong>{@totalPoints()}</strong>
+              <strong>{@props.jam.getPoints()}</strong>
             </div>
           </div>
         </div>

--- a/app/scripts/components/scorekeeper/jam_item.cjsx
+++ b/app/scripts/components/scorekeeper/jam_item.cjsx
@@ -1,4 +1,7 @@
 React = require 'react/addons'
+AppDispatcher = require '../../dispatcher/app_dispatcher.coffee'
+{ActionTypes} = require '../../constants.coffee'
+SkaterSelector = require '../shared/skater_selector.cjsx'
 ScoreNote = require './score_note.cjsx'
 cx = React.addons.classSet
 module.exports = React.createClass
@@ -6,50 +9,45 @@ module.exports = React.createClass
   propTypes:
     jam: React.PropTypes.object.isRequired
     selectionHandler: React.PropTypes.func
-  totalPoints: () ->
-    points = 0
-    @props.jam.getPasses().map (pass) =>
-      points += pass.points ? 0
-    return points
-  getNotes: () ->
-    jam = @props.jam
-    flags = jam.getPasses().reduce (prev, pass) ->
-      injury: prev.injury or pass.injury
-      nopass: prev.nopass or pass.nopass
-      calloff: prev.calloff or pass.calloff
-      lost: prev.lost  or pass.lostLead
-      lead: prev.lead or pass.lead
-    , {}
-    Object.keys(flags).filter (key) ->
-      flags[key]
+  setJammer: (skaterId) ->
+    AppDispatcher.dispatchAndEmit
+      type: ActionTypes.SET_SKATER_POSITION
+      jamId: @props.jam.id
+      position: 'jammer'
+      skaterId: skaterId
   render: () ->
-    notes = @getNotes()
+    notes = @props.jam.getNotes()
     jammer = @props.jam.jammer
     jammerNumber = if jammer? then jammer.number else <span>&nbsp;</span>
     <div className="jam-row">
-      <div className="row gutters-xs" onClick={@props.selectionHandler} >
-        <div className="col-sm-2 col-xs-2">
+      <div className="row gutters-xs">
+        <div className="col-sm-2 col-xs-2" onClick={@props.selectionHandler}>
           <div className="jam boxed-good text-center">
             {@props.jam.jamNumber}
           </div>
         </div>
         <div className="col-sm-2 col-xs-2">
-          <div className='boxed-good text-center'>
-            <strong>{jammerNumber}</strong>
+          <SkaterSelector
+            skater={@props.jam.jammer}
+            injured={@props.jam.isInjured('jammer')}
+            style={@props.style}
+            setSelectorContext={@props.setSelectorContext}
+            selectHandler={@setJammer} />
+        </div>
+        <div onClick={@props.selectionHandler}>
+          <div className="col-sm-2 col-xs-2">
+            <ScoreNote note={notes[0]}/>
           </div>
-        </div>
-        <div className="col-sm-2 col-xs-2">
-          <ScoreNote note={notes[0]}/>
-        </div>
-        <div className="col-sm-2 col-xs-2">
-          <ScoreNote note={notes[1]}/>
-        </div>
-        <div className="col-sm-2 col-xs-2">
-          <ScoreNote note={notes[2]}/>
-        </div>
-        <div className="col-sm-2 col-xs-2">
-          <div className="points boxed-good text-center">
-            <strong>{@totalPoints()}</strong>
+          <div className="col-sm-2 col-xs-2">
+            <ScoreNote note={notes[1]}/>
+          </div>
+          <div className="col-sm-2 col-xs-2">
+            <ScoreNote note={notes[2]}/>
+          </div>
+          <div className="col-sm-2 col-xs-2">
+            <div className="points boxed-good text-center">
+              <strong>{@props.jam.getPoints()}</strong>
+            </div>
           </div>
         </div>
       </div>

--- a/app/scripts/components/scorekeeper/pass_edit_panel.cjsx
+++ b/app/scripts/components/scorekeeper/pass_edit_panel.cjsx
@@ -25,6 +25,12 @@ module.exports = React.createClass
     AppDispatcher.dispatchAndEmit
       type: ActionTypes.TOGGLE_LEAD
       passId: @props.pass.id
+  setStarPass: () ->
+    AppDispatcher.dispatchAndEmit
+      type: ActionTypes.SET_STAR_PASS
+      passId: @props.pass.id
+      newPassId: functions.uniqueId()
+    $("##{@props.editPassId}").collapse('hide')
   setPoints: (points) ->
     AppDispatcher.dispatchAndEmit
       type: ActionTypes.SET_POINTS
@@ -32,7 +38,21 @@ module.exports = React.createClass
       newPassId: functions.uniqueId()
       points: points
     $("##{@props.editPassId}").collapse('hide')
+  isFirstPass: () ->
+    @props.pass.passNumber == 1
   render: () ->
+    leadColumnClass = cx
+      'col-sm-3 col-xs-3': true
+      'hidden': not @isFirstPass()
+    lostLeadColumnClass = cx
+      'col-sm-3 col-xs-3': true
+      'hidden': @isFirstPass()
+    firstPassScoreRowClass = cx
+      'row gutters-xs': true
+      'hidden': not @isFirstPass()
+    scoreRowClass = cx
+      'row gutters-xs': true
+      'hidden': @isFirstPass()
     injuryClass = cx
       'bt-btn notes injury': true
       'selected': @props.pass.injury
@@ -48,6 +68,9 @@ module.exports = React.createClass
     leadClass = cx
       'bt-btn notes note-lead': true
       'selected': @props.pass.lead
+    starPassClass = cx
+      'bt-btn notes star-pass': true
+      'selected': @props.jam.starPass and @props.jam.starPassNumber is @props.pass.passNumber
     zeroClass = cx
       'bt-btn scores zero': true
       'selected': @props.pass.points == 0
@@ -69,105 +92,92 @@ module.exports = React.createClass
     sixClass = cx
       'bt-btn scores six': true
       'selected': @props.pass.points == 6
-    if @props.pass.passNumber == 1
-      <div className="panel">
-        <div className="edit-pass first-pass collapse" id={@props.editPassId}>
-          <div className="row gutters-xs">
-            <div className="col-sm-4 col-xs-4">
-              <button className={injuryClass} onClick={@toggleInjury}>
-                <strong>Injury</strong>
-              </button>
-            </div>
-            <div className="col-sm-4 col-xs-4">
-              <button className={leadClass} onClick={@toggleLead}>
-                <strong>Lead</strong>
-              </button>
-            </div>
-            <div className="col-sm-4 col-xs-4">
-              <button className={callClass} onClick={@toggleCalloff}>
-                <strong>Call</strong>
-              </button>
-            </div>
+    <div className="panel">
+      <div className="edit-pass collapse" id={@props.editPassId}>
+        <div className="row gutters-xs">
+          <div className="col-sm-3 col-xs-3">
+            <button className={injuryClass} onClick={@toggleInjury}>
+              <strong>Injury</strong>
+            </button>
           </div>
-          <div className="row gutters-xs">
-            <div className="col-sm-4 col-xs-4">
-              <button className={zeroClass} onClick={@setPoints.bind(this, 0)}>
-                <strong>0</strong>
-              </button>
-            </div>
-            <div className="col-sm-4 col-xs-4">
-              <button className={oneClass} onClick={@setPoints.bind(this, 1)}>
-                <strong>1</strong>
-              </button>
-            </div>
-            <div className="col-sm-4 col-xs-4">
-              <button className={nopassClass} onClick={@toggleNopass}>
-                <strong>No P.</strong>
-              </button>
-            </div>
+          <div className={leadColumnClass}>
+            <button className={leadClass} onClick={@toggleLead}>
+              <strong>Lead</strong>
+            </button>
+          </div>
+          <div className={lostLeadColumnClass}>
+            <button className={lostClass} onClick={@toggleLostLead}>
+              <strong>Lost</strong>
+            </button>
+          </div>
+          <div className="col-sm-3 col-xs-3">
+            <button className={callClass} onClick={@toggleCalloff}>
+              <strong>Call</strong>
+            </button>
+          </div>
+          <div className="col-sm-3 col-xs-3">
+            <button className={starPassClass} onClick={@setStarPass}>
+              <strong><span className="glyphicon glyphicon-star" aria-hidden="true"></span> Pass</strong>
+            </button>
           </div>
         </div>
-      </div>
-    else
-      <div className="panel">
-        <div className="edit-pass second-pass collapse" id={@props.editPassId}>
-          <div className="row gutters-xs">
-            <div className="col-sm-4 col-xs-4">
-              <button className={injuryClass} onClick={@toggleInjury}>
-                <strong>Injury</strong>
-              </button>
-            </div>
-            <div className="col-sm-4 col-xs-4">
-              <button className={lostClass} onClick={@toggleLostLead}>
-                <strong>Lost</strong>
-              </button>
-            </div>
-            <div className="col-sm-4 col-xs-4">
-              <button className={callClass} onClick={@toggleCalloff}>
-                <strong>Call</strong>
-              </button>
-            </div>
+        <div className={firstPassScoreRowClass}>
+          <div className="col-sm-4 col-xs-4">
+            <button className={zeroClass} onClick={@setPoints.bind(this, 0)}>
+              <strong>0</strong>
+            </button>
           </div>
-          <div className="row gutters-xs">
-            <div className="col-sm-11 col-xs-11">
-              <div className="row gutters-xs">
-                <div className="col-sm-2 col-xs-2">
-                  <button className={zeroClass} onClick={@setPoints.bind(this, 0)}>
-                    <strong>0</strong>
-                  </button>
-                </div>
-                <div className="col-sm-2 col-xs-2">
-                  <button className={oneClass} onClick={@setPoints.bind(this, 1)}>
-                    <strong>1</strong>
-                  </button>
-                </div>
-                <div className="col-sm-2 col-xs-2">
-                  <button className={twoClass} onClick={@setPoints.bind(this, 2)}>
-                    <strong>2</strong>
-                  </button>
-                </div>
-                <div className="col-sm-2 col-xs-2">
-                  <button className={threeClass} onClick={@setPoints.bind(this, 3)}>
-                    <strong>3</strong>
-                  </button>
-                </div>
-                <div className="col-sm-2 col-xs-2">
-                  <button className={fourClass} onClick={@setPoints.bind(this, 4)}>
-                    <strong>4</strong>
-                  </button>
-                </div>
-                <div className="col-sm-2 col-xs-2">
-                  <button className={fiveClass} onClick={@setPoints.bind(this, 5)}>
-                    <strong>5</strong>
-                  </button>
-                </div>
+          <div className="col-sm-4 col-xs-4">
+            <button className={oneClass} onClick={@setPoints.bind(this, 1)}>
+              <strong>1</strong>
+            </button>
+          </div>
+          <div className="col-sm-4 col-xs-4">
+            <button className={nopassClass} onClick={@toggleNopass}>
+              <strong>No P.</strong>
+            </button>
+          </div>
+        </div>
+        <div className={scoreRowClass}>
+          <div className="col-sm-11 col-xs-11">
+            <div className="row gutters-xs">
+              <div className="col-sm-2 col-xs-2">
+                <button className={zeroClass} onClick={@setPoints.bind(this, 0)}>
+                  <strong>0</strong>
+                </button>
+              </div>
+              <div className="col-sm-2 col-xs-2">
+                <button className={oneClass} onClick={@setPoints.bind(this, 1)}>
+                  <strong>1</strong>
+                </button>
+              </div>
+              <div className="col-sm-2 col-xs-2">
+                <button className={twoClass} onClick={@setPoints.bind(this, 2)}>
+                  <strong>2</strong>
+                </button>
+              </div>
+              <div className="col-sm-2 col-xs-2">
+                <button className={threeClass} onClick={@setPoints.bind(this, 3)}>
+                  <strong>3</strong>
+                </button>
+              </div>
+              <div className="col-sm-2 col-xs-2">
+                <button className={fourClass} onClick={@setPoints.bind(this, 4)}>
+                  <strong>4</strong>
+                </button>
+              </div>
+              <div className="col-sm-2 col-xs-2">
+                <button className={fiveClass} onClick={@setPoints.bind(this, 5)}>
+                  <strong>5</strong>
+                </button>
               </div>
             </div>
-            <div className="col-sm-1 col-xs-1">
-              <button className={sixClass} onClick={@setPoints.bind(this, 6)}>
-                <strong>6</strong>
-              </button>
-            </div>
+          </div>
+          <div className="col-sm-1 col-xs-1">
+            <button className={sixClass} onClick={@setPoints.bind(this, 6)}>
+              <strong>6</strong>
+            </button>
           </div>
         </div>
       </div>
+    </div>

--- a/app/scripts/components/scorekeeper/pass_item.cjsx
+++ b/app/scripts/components/scorekeeper/pass_item.cjsx
@@ -1,36 +1,14 @@
 React = require 'react/addons'
-AppDispatcher = require '../../dispatcher/app_dispatcher.coffee'
-{ActionTypes} = require '../../constants.coffee'
 functions = require '../../functions.coffee'
-SkaterSelector = require '../shared/skater_selector.cjsx'
 ScoreNote = require './score_note.cjsx'
 PassEditPanel = require './pass_edit_panel.cjsx'
 cx = React.addons.classSet
 module.exports = React.createClass
   displayName: 'PassItem'
   propTypes:
-    jam: React.PropTypes.object.isRequired
     pass: React.PropTypes.object.isRequired
-  setSkater: (skaterId) ->
-    AppDispatcher.dispatchAndEmit
-      type: ActionTypes.SET_PASS_JAMMER
-      passId: @props.pass.id
-      skaterId: skaterId
-  isInjured: (position) ->
-    @props.jam.lineupStatuses? and @props.jam.lineupStatuses.some (status) ->
-      status[position] is 'injured'
   hidePanels: () ->
     $('.scorekeeper .collapse.in').collapse('hide');
-  getNotes: () ->
-    pass = @props.pass
-    flags =
-      injury: pass.injury
-      nopass: pass.nopass
-      calloff: pass.calloff
-      lost: pass.lostLead
-      lead: pass.lead
-    Object.keys(flags).filter (key) ->
-      flags[key]
   preventDefault: (evt) ->
     evt.preventDefault()
   render: () ->
@@ -50,7 +28,9 @@ module.exports = React.createClass
       'lost': true
       'text-center': true
     editPassId = "edit-pass-#{functions.uniqueId()}"
-    notes = @getNotes()
+    notes = @props.pass.getNotes()
+    jammer = if @props.jam.starPass and @props.pass.passNumber > @props.jam.starPassNumber then @props.jam.pivot else @props.jam.jammer
+    jammerNumber = if jammer? then jammer.number else <span>&nbsp;</span>
     <div aria-multiselectable="true" draggable='true' onDragStart={@props.dragHandler} onDragOver={@preventDefault} onDrop={@props.dropHandler} onMouseDown={@props.mouseDownHandler}>
       <div className="columns">
         <div className="row gutters-xs">
@@ -66,13 +46,10 @@ module.exports = React.createClass
               </div>
             </div>
             <div className="col-sm-2 col-xs-2">
-              <SkaterSelector
-                skater={@props.pass.jammer}
-                injured={@isInjured('jammer')}
-                style={@props.style}
-                setSelectorContext={@props.setSelectorContext}
-                selectHandler={@setSkater} />
+              <div className='boxed-good text-center'>
+                <strong>{jammerNumber}</strong>
               </div>
+            </div>
             <div data-toggle="collapse" data-target={"##{editPassId}"} aria-expanded="false" aria-controls={editPassId} onClick={@hidePanels}>
               <div className="col-sm-2 col-xs-2">
                 <ScoreNote note={notes[0]} />

--- a/app/scripts/components/scorekeeper/passes_list.cjsx
+++ b/app/scripts/components/scorekeeper/passes_list.cjsx
@@ -23,11 +23,11 @@ module.exports = React.createClass
       targetPassIndex: passIndex
   render: () ->
     PassItemFactory = React.createFactory(PassItem)
-    passComponents = @props.jam.getPasses().map (pass, passIndex) =>
+    passComponents = @props.jam.passes.map (pass, passIndex) =>
       PassItemFactory(
         key: passIndex
-        jam: @props.jam
         pass: pass
+        jam: @props.jam
         setSelectorContext: @props.setSelectorContext
         dragHandler: @dragHandler.bind(this, passIndex)
         dropHandler: @dropHandler.bind(this, passIndex)

--- a/app/scripts/constants.coffee
+++ b/app/scripts/constants.coffee
@@ -58,6 +58,7 @@ module.exports =
     TOGGLE_CALLOFF: null
     TOGGLE_LOST_LEAD: null
     TOGGLE_LEAD: null
+    SET_STAR_PASS: null
     SET_POINTS: null
     REORDER_PASS: null
     SET_PASS_JAMMER: null

--- a/app/scripts/models/pass.coffee
+++ b/app/scripts/models/pass.coffee
@@ -31,6 +31,11 @@ class Pass extends Store
         pass.toggleLead()
         pass.save()
         @emitChange()
+      when ActionTypes.SET_STAR_PASS
+        pass = @find(action.passId)
+        pass.setPoints(0)
+        pass.save()
+        @emitChange()
       when ActionTypes.SET_POINTS
         pass = @find(action.passId)
         pass.setPoints(action.points)
@@ -66,4 +71,13 @@ class Pass extends Store
     @points = points
   setJammer: (skaterId) ->
     @jammer = Skater.find(skaterId)
+  getNotes: () ->
+    flags =
+      injury: @injury
+      nopass: @nopass
+      calloff: @calloff
+      lost: @lostLead
+      lead: @lead
+    Object.keys(flags).filter (key) ->
+      flags[key]
 module.exports = Pass


### PR DESCRIPTION
Minor redesign in scorekeeper
The jammer for a pass is no longer individually selectable. Instead there is a new Star Pass button in the edit panel for a pass. Pressing this when it is currently unselected will set the Star Pass flag for that jam to true, set points for that pass to 0, and close the edit panel for that pass. The Jammer number for passes up until a star pass will be the lineup's jammer. Subsequent passes will list the lineup's pivot
