### PR TITLE
Explicitly add jams and passes

### DIFF
--- a/app/scripts/components/scorekeeper/jams_list.cjsx
+++ b/app/scripts/components/scorekeeper/jams_list.cjsx
@@ -16,11 +16,7 @@ module.exports = React.createClass
     @props.team.jams[@state.jamSelected ? 0]
   handleMainMenu: () ->
     @setState(jamSelected: null)
-  handleJamSelection: (jamIndex, newJam) ->
-    if newJam
-      AppDispatcher.dispatch
-        type: ActionTypes.CREATE_NEXT_JAM
-        teamId: @props.team.id
+  handleJamSelection: (jamIndex) ->
     @setState(jamSelected: jamIndex)
   handleNextJam: () ->
     if @state.jamSelected < @props.team.jams.length - 1
@@ -30,28 +26,13 @@ module.exports = React.createClass
     if @state.jamSelected > 0
       $('.scorekeeper .collapse.in').collapse('hide')
       @setState(jamSelected: @state.jamSelected - 1)
+  createNextJam: () ->
+    AppDispatcher.dispatch
+      type: ActionTypes.CREATE_NEXT_JAM
+      teamId: @props.team.id
   getInitialState: () ->
     jamSelected: null
   render: () ->
-    JamItemFactory = React.createFactory(JamItem)
-    # jam's schema is same as jam_state table
-    jamComponents = @props.team.jams.map (jam, jamIndex) =>
-      JamItemFactory
-        key: jamIndex
-        jam: jam
-        setSelectorContext: @props.setSelectorContext.bind(this, jam)
-        style: @props.team.colorBarStyle
-        selectionHandler: @handleJamSelection.bind(this, jamIndex, false)
-    # add a blank jam for adding a next jam
-    emptyJam = new Jam(jamNumber: @props.team.jams.length+1, teamId: @props.team.id)
-    jamComponents.push(
-      JamItemFactory
-        key: @props.team.jams.length
-        jam: emptyJam
-        setSelectorContext: @props.setSelectorContext.bind(this, emptyJam)
-        style: @props.team.colorBarStyle
-        selectionHandler: @handleJamSelection.bind(this, @props.team.jams.length, true)
-    )
     jamsContainerClass = cx
       'jams fade-hide': true
       'in': !@state.jamSelected?
@@ -103,7 +84,21 @@ module.exports = React.createClass
           </div>
         </div>
         <div className="columns">
-          {jamComponents}
+          {@props.team.jams.map (jam, jamIndex) ->
+            <JamItem
+              key={jamIndex}
+              jam={jam}
+              setSelectorContext={@props.setSelectorContext.bind(this, jam)}
+              style={@props.team.colorBarStyle}
+              selectionHandler={@handleJamSelection.bind(this, jamIndex)} />
+          , this}
+        </div>
+        <div className="actions">
+          <div className="row gutters-xs">
+            <div className="col-sm-12 col-xs-12">
+              <button className="bt-btn action" onClick={@createNextJam}>Next Jam</button>
+            </div>
+          </div>
         </div>
       </div>
       <div className={passesContainerClass}>

--- a/app/scripts/components/scorekeeper/pass_edit_panel.cjsx
+++ b/app/scripts/components/scorekeeper/pass_edit_panel.cjsx
@@ -2,7 +2,6 @@ React = require 'react/addons'
 $ = require 'jquery'
 AppDispatcher = require '../../dispatcher/app_dispatcher.coffee'
 {ActionTypes} = require '../../constants.coffee'
-functions = require '../../functions.coffee'
 cx = React.addons.classSet
 module.exports = React.createClass
   displayName: 'PassEditPanel'
@@ -34,13 +33,11 @@ module.exports = React.createClass
     AppDispatcher.dispatchAndEmit
       type: ActionTypes.SET_STAR_PASS
       passId: @props.pass.id
-      newPassId: functions.uniqueId()
     $("##{@props.editPassId}").collapse('hide')
   setPoints: (points) ->
     AppDispatcher.dispatchAndEmit
       type: ActionTypes.SET_POINTS
       passId: @props.pass.id
-      newPassId: functions.uniqueId()
       points: points
     $("##{@props.editPassId}").collapse('hide')
   isFirstPass: () ->

--- a/app/scripts/components/scorekeeper/pass_item.cjsx
+++ b/app/scripts/components/scorekeeper/pass_item.cjsx
@@ -42,42 +42,40 @@ module.exports = React.createClass
     editPassId = "edit-pass-#{functions.uniqueId()}"
     notes = @props.pass.getNotes()
     jammer = @props.jam[@jammerLineupPosition()]
-    <div aria-multiselectable="true" draggable='true' onDragStart={@props.dragHandler} onDragOver={@preventDefault} onDrop={@props.dropHandler} onMouseDown={@props.mouseDownHandler}>
-      <div className="columns">
-        <div className="row gutters-xs">
-          <div className="col-sm-1 col-xs-1">
-            <div className="drag-handle">
-              <span className="glyphicon glyphicon-th-list" />
+    <div className='pass-row' aria-multiselectable="true" draggable='true' onDragStart={@props.dragHandler} onDragOver={@preventDefault} onDrop={@props.dropHandler} onMouseDown={@props.mouseDownHandler}>
+      <div className="row gutters-xs">
+        <div className="col-sm-1 col-xs-1">
+          <div className="drag-handle">
+            <span className="glyphicon glyphicon-th-list" />
+          </div>
+        </div>
+        <div className="col-sm-11 col-xs-11">
+          <div className="col-sm-2 col-xs-2">
+            <div className="pass boxed-good text-center" >
+              {@props.pass.passNumber}
             </div>
           </div>
-          <div className="col-sm-11 col-xs-11">
+          <div className="col-sm-2 col-xs-2">
+              <SkaterSelector
+                skater={jammer}
+                injured={@props.jam.isInjured(@jammerLineupPosition())}
+                style={@props.style}
+                setSelectorContext={@props.setSelectorContext}
+                selectHandler={@setJammer} />
+          </div>
+          <div data-toggle="collapse" data-target={"##{editPassId}"} aria-expanded="false" aria-controls={editPassId} onClick={@hidePanels}>
             <div className="col-sm-2 col-xs-2">
-              <div className="pass boxed-good text-center" >
-                {@props.pass.passNumber}
-              </div>
+              <ScoreNote note={notes[0]} />
             </div>
             <div className="col-sm-2 col-xs-2">
-                <SkaterSelector
-                  skater={jammer}
-                  injured={@props.jam.isInjured(@jammerLineupPosition())}
-                  style={@props.style}
-                  setSelectorContext={@props.setSelectorContext}
-                  selectHandler={@setJammer} />
+              <ScoreNote note={notes[1]} />
             </div>
-            <div data-toggle="collapse" data-target={"##{editPassId}"} aria-expanded="false" aria-controls={editPassId} onClick={@hidePanels}>
-              <div className="col-sm-2 col-xs-2">
-                <ScoreNote note={notes[0]} />
-              </div>
-              <div className="col-sm-2 col-xs-2">
-                <ScoreNote note={notes[1]} />
-              </div>
-              <div className="col-sm-2 col-xs-2">
-                <ScoreNote note={notes[2]} />
-              </div>
-              <div className="col-sm-2 col-xs-2">
-                <div className="points boxed-good text-center">
-                  <strong>{@props.pass.points ? 0}</strong>
-                </div>
+            <div className="col-sm-2 col-xs-2">
+              <ScoreNote note={notes[2]} />
+            </div>
+            <div className="col-sm-2 col-xs-2">
+              <div className="points boxed-good text-center">
+                <strong>{@props.pass.points ? 0}</strong>
               </div>
             </div>
           </div>

--- a/app/scripts/components/scorekeeper/passes_list.cjsx
+++ b/app/scripts/components/scorekeeper/passes_list.cjsx
@@ -1,5 +1,6 @@
 React = require 'react/addons'
 $ = require 'jquery'
+functions = require '../../functions'
 AppDispatcher = require '../../dispatcher/app_dispatcher.coffee'
 {ActionTypes} = require '../../constants.coffee'
 PassItem = require './pass_item.cjsx'
@@ -22,18 +23,12 @@ module.exports = React.createClass
       jamId: @props.jam.id
       sourcePassIndex: sourceIndex
       targetPassIndex: passIndex
+  createNextPass: () ->
+    AppDispatcher.dispatchAndEmit
+      type: ActionTypes.CREATE_NEXT_PASS
+      jamId: @props.jam.id
+      passId: functions.uniqueId()
   render: () ->
-    PassItemFactory = React.createFactory(PassItem)
-    passComponents = @props.jam.passes.map (pass, passIndex) =>
-      PassItemFactory(
-        key: passIndex
-        pass: pass
-        jam: @props.jam
-        setSelectorContext: @props.setSelectorContext
-        dragHandler: @dragHandler.bind(this, passIndex)
-        dropHandler: @dropHandler.bind(this, passIndex)
-        mouseDownHandler: @mouseDownHandler
-      )
     <div className="passes">
       <div className="headers">
         <div className="row gutters-xs">
@@ -55,5 +50,23 @@ module.exports = React.createClass
           </div>
         </div>
       </div>
-      {passComponents}
+      <div className="columns">
+        {@props.jam.passes.map (pass, passIndex) ->
+          <PassItem
+            key={passIndex}
+            pass={pass}
+            jam={@props.jam}
+            setSelectorContext={@props.setSelectorContext}
+            dragHandler={@dragHandler.bind(this, passIndex)}
+            dropHandler={@dropHandler.bind(this, passIndex)}
+            mouseDownHandler={@mouseDownHandler} />
+        , this}
+      </div>
+      <div className="actions">
+        <div className="row gutters-xs">
+          <div className="col-sm-12 col-xs-12">
+            <button className="bt-btn action" onClick={@createNextPass}>Next Pass</button>
+          </div>
+        </div>
+      </div>
     </div>

--- a/app/scripts/components/scorekeeper/score_note.cjsx
+++ b/app/scripts/components/scorekeeper/score_note.cjsx
@@ -13,11 +13,9 @@ module.exports = React.createClass
       when 'lost' then 'Lost'
       else <span>&nbsp;</span>
   render: () ->
-    noteClassArgs =
+    noteClass = cx
       'selected': @props.note?
       'boxed-good text-center notes': true
-    noteClassArgs[@props.note] = true
-    noteClass = cx noteClassArgs
     <div className={noteClass}>
       <strong>{@noteContent()}</strong>
     </div>

--- a/app/scripts/constants.coffee
+++ b/app/scripts/constants.coffee
@@ -53,6 +53,7 @@ module.exports =
     SET_SKATER_POSITION: null
     CYCLE_LINEUP_STATUS: null
     CREATE_NEXT_JAM: null
+    CREATE_NEXT_PASS: null
     TOGGLE_INJURY: null
     TOGGLE_NOPASS: null
     TOGGLE_CALLOFF: null

--- a/app/scripts/models/jam.coffee
+++ b/app/scripts/models/jam.coffee
@@ -23,7 +23,6 @@ class Jam extends Store
         pass = Pass.find(action.passId)
         jam = Jam.find(pass.jamId)
         jam.setStarPass(pass)
-        jam.createNextPass(action.newPassId) if pass.id is jam.getLastPass().id
         jam.save()
         @emitChange()
         return jam
@@ -39,25 +38,15 @@ class Jam extends Store
         jam.save()
         @emitChange()
         return jam
-      when ActionTypes.TOGGLE_LEAD
-        AppDispatcher.waitFor([Pass.dispatchToken])
-        pass = Pass.find(action.passId)
-        jam = Jam.find(pass.jamId)
-        jam.createNextPass(action.newPassId) if pass.id is jam.getLastPass().id
-        jam.save()
-        @emitChange()
-        return jam
-      when ActionTypes.SET_POINTS
-        AppDispatcher.waitFor([Pass.dispatchToken])
-        pass = Pass.find(action.passId)
-        jam = Jam.find(pass.jamId)
-        jam.createNextPass(action.newPassId) if pass.id is jam.getLastPass().id
-        jam.save()
-        @emitChange()
-        return jam
       when ActionTypes.REORDER_PASS
         jam = @find(action.jamId)
         jam.reorderPass(action.sourcePassIndex, action.targetPassIndex)
+        jam.save()
+        @emitChange()
+        return jam
+      when ActionTypes.CREATE_NEXT_PASS
+        jam = @find(action.jamId)
+        jam.createNextPass(action.passId)
         jam.save()
         @emitChange()
         return jam
@@ -99,8 +88,6 @@ class Jam extends Store
   getPasses: () ->
     Pass.findBy(jamId: @id).sort (a, b) ->
       a.passNumber - b.passNumber
-  getLastPass: () ->
-    @passes[@passes.length - 1]
   getPositionsInBox: () ->
     positions = []
     for row in @lineupStatuses
@@ -149,10 +136,8 @@ class Jam extends Store
     currentStatus = @lineupStatuses[statusIndex][position]
     @lineupStatuses[statusIndex][position] = @statusTransition(currentStatus)
   createNextPass: (passId) ->
-    lastPass = @getLastPass()
-    newPass = new Pass(id: passId, passNumber: lastPass.passNumber + 1, jamId: @id)
+    newPass = new Pass(id: passId, passNumber: @passes.length + 1, jamId: @id)
     @passes.push newPass
-    @save()
   reorderPass: (sourcePassIndex, targetPassIndex) ->
     @passes.splice(targetPassIndex, 0, @passes.splice(sourcePassIndex, 1)[0])
     pass.passNumber = i + 1 for pass, i in @passes

--- a/app/styles/_scorekeeper.scss
+++ b/app/styles/_scorekeeper.scss
@@ -1,7 +1,7 @@
 .fade-hide {
   position:absolute;
-  left:0;
-  right:0;
+  left:2px;
+  right:2px;
   opacity: 0;
   visibility: hidden;
   transition: opacity 0.15s, visibility 0.15s;
@@ -10,9 +10,6 @@
     visibility: visible;
     transition-delay: 0.15s;
   }
-}
-.row.gutters-xs {
-  @include gutters-xs;
 }
 .scorekeeper {
   .stats {
@@ -34,8 +31,7 @@
     .headers {
     }
     .columns {
-      margin-top: 4px;
-      .jam-row{
+      .jam-row, .pass-row{
         margin-top: 4px;
       }
       .col-sm-2, .col-xs-2 {
@@ -82,6 +78,16 @@
         cursor: move;
       }
     }
+    .actions {
+      margin-top: 4px;
+      .action {
+        background-color: $near-black;
+        border-color: $near-black;
+        color: $white;
+        text-transform: uppercase;
+      }
+    }
+
     // because collapse requires a .panel to work with data-parent,
     // https://github.com/twbs/bootstrap/blob/a577f1922ee7054a97b455ccfaa16857cb2b79fc/js/collapse.js#L49,
     // but we don't want the .panel styles.

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -157,3 +157,6 @@ $input-color: $near-black;
   margin-top: 0;
   width: 50%;
 }
+.row.gutters-xs {
+  @include gutters-xs;
+}

--- a/test/models/jam-test.coffee
+++ b/test/models/jam-test.coffee
@@ -42,6 +42,7 @@ describe 'Jam', () ->
           passNumber: 1
       expect(jam.starPass).toBe(true)
       expect(jam.starPassNumber).toBe(1)
+      expect(jam.passes.length).toBe(1)
     it "sets a skater to a position", () ->
       jam = callback
         type: ActionTypes.SET_SKATER_POSITION
@@ -64,3 +65,9 @@ describe 'Jam', () ->
         sourcePassIndex: 0
         targetPassIndex: 1
       expect(jam.reorderPass).toHaveBeenCalledWith(0, 1)
+    it "creates a new pass", () ->
+      jam = callback
+        type: ActionTypes.CREATE_NEXT_PASS
+        jamId: jam.id
+        passId: 'pass 2'
+      expect(jam.passes.length).toBe(2)


### PR DESCRIPTION
Explicitly add new jams and passes. Jam and pass creation is no longer a side effect of any other action such as setting points or lead.

This PR does not include any workflow for removing jams or passes. Creation in the scorekeeper looks and behaves like jam creation in the Lineup Tracker, using a "Next Jam" or "Next Pass" button at the bottom of a list. So new functionality and look/feel is consistent with existing functionality and look/feel. At no point have the various roles had the ability to remove jams or passes. If that is desired functionality, please provide designs or descriptions of how that workflow would look.

Bonus: This PR also fixes several minor display issues affecting the scorekeeper interface
