### PR TITLE
use initials in PBT selector placeholders

### DIFF
--- a/app/scripts/components/penalty_box_timer/penalty_clock.cjsx
+++ b/app/scripts/components/penalty_box_timer/penalty_clock.cjsx
@@ -32,12 +32,6 @@ module.exports = React.createClass
       boxIndexOrPosition: @props.boxIndex ? @props.boxState.position
       skaterId: skaterId
       clockId: functions.uniqueId()
-  addPenaltyTime: () ->
-    return if not @props.boxIndex?
-    AppDispatcher.dispatchAndEmit
-      type: ActionTypes.ADD_PENALTY_TIME
-      teamId: @props.team.id
-      boxIndex: @props.boxIndex
   togglePenaltyTimer: () ->
     return if not @props.boxIndex?
     AppDispatcher.dispatchAndEmit
@@ -47,8 +41,8 @@ module.exports = React.createClass
   render: () ->
     teamStyle = @props.team.colorBarStyle
     placeholder = switch @props.boxState.position
-      when 'jammer' then "J"
-      when 'blocker' then "B"
+      when 'jammer' then "Jammer"
+      when 'blocker' then "Blocker"
     containerClass = cx
       'penalty-clock': true
       'hidden': @props.hidden
@@ -62,10 +56,7 @@ module.exports = React.createClass
       <div className="row gutters-xs top-buffer">
         <div className="col-xs-6">
           <div className="row gutters-xs">
-            <div className="col-xs-6">
-              <button className="bt-btn" onClick={@addPenaltyTime}>+30</button>
-            </div>
-            <div className="col-xs-6">
+            <div className="col-xs-12">
               <SkaterSelector
                 skater={@props.boxState.skater}
                 style={teamStyle}
@@ -89,7 +80,6 @@ module.exports = React.createClass
           </div>
         </div>
         <div className="col-xs-6">
-          <div className="penalty-count bt-box box-primary">{@props.boxState.penaltyCount}</div>
           <button className="bt-btn btn-default clock" id={@clockId} onClick={@togglePenaltyTimer}>{@props.boxState.clock.display()}</button>
         </div>
       </div>

--- a/app/scripts/constants.coffee
+++ b/app/scripts/constants.coffee
@@ -69,7 +69,6 @@ module.exports =
     TOGGLE_LEFT_EARLY: null
     TOGGLE_PENALTY_SERVED: null
     SET_PENALTY_BOX_SKATER: null
-    ADD_PENALTY_TIME: null
     TOGGLE_PENALTY_TIMER: null
     TOGGLE_ALL_PENALTY_TIMERS: null
     SAVE_GAME: null

--- a/app/scripts/models/team.coffee
+++ b/app/scripts/models/team.coffee
@@ -9,8 +9,8 @@ Store = require './store'
 Jam = require './jam'
 Skater = require './skater'
 PENALTY_CLOCK_SETTINGS =
-  time: constants.PENALTY_DURATION_IN_MS
-  warningTime: constants.PENALTY_WARNING_IN_MS
+  time: 0
+  tickUp: true
 class Team extends Store
   @dispatchToken: AppDispatcher.register (action) =>
     switch action.type
@@ -31,10 +31,6 @@ class Team extends Store
         @find(action.teamId).tap (team) =>
           team.setPenaltyBoxSkater(action.boxIndexOrPosition, action.clockId, action.skaterId)
         .then (team) ->
-          team.save()
-      when ActionTypes.ADD_PENALTY_TIME
-        @find(action.teamId).then (team) =>
-          team.addPenaltyTime(action.boxIndex)
           team.save()
       when ActionTypes.TOGGLE_PENALTY_TIMER
         @find(action.teamId).then (team) =>
@@ -124,11 +120,6 @@ class Team extends Store
     if box?
       box.served = !box.served
       box.leftEarly = false
-  addPenaltyTime: (boxIndex)->
-    box = @penaltyBoxStates[boxIndex]
-    if box?
-      box.penaltyCount += 1
-      box.clock.time += constants.PENALTY_DURATION_IN_MS
   togglePenaltyTimer: (boxIndex) ->
     box = @penaltyBoxStates[boxIndex]
     if box?
@@ -147,7 +138,6 @@ class Team extends Store
       box.skater = skater
   newPenaltyBoxState: (position, clockId) ->
     position: position
-    penaltyCount: 1
     clock: @clockManager.addClock(clockId ? functions.uniqueId(), PENALTY_CLOCK_SETTINGS)
   getOrCreatePenaltyBoxState: (boxIndexOrPosition, clockId) ->
     switch typeof boxIndexOrPosition

--- a/test/models/team-test.coffee
+++ b/test/models/team-test.coffee
@@ -102,15 +102,6 @@ describe 'Team', () ->
         .then (team) ->
           boxState = team.penaltyBoxStates[0]
           expect(boxState.served).toBe(true)
-      pit "adds penalty time", () ->
-        team.then (team) ->
-          callback
-            type: ActionTypes.ADD_PENALTY_TIME
-            teamId: team.id
-            boxIndex: 0
-        .then (team) ->
-          boxState = team.penaltyBoxStates[0]
-          expect(boxState.penaltyCount).toBe(2)
       pit "toggles the penalty timer", () ->
         team.then (team) ->
           callback


### PR DESCRIPTION
The Skater Selector placeholder texts (with chevrons) were overflowing the buttons on some screen sizes. This PR switches the placeholders to initials (J and B instead of Jammer and Blocker).
