### PR TITLE
Resume period clock on starting a jam after a timeout

### DIFF
--- a/app/scripts/models/game_state.coffee
+++ b/app/scripts/models/game_state.coffee
@@ -240,8 +240,7 @@ class GameState extends Store
       @period = "period 2"
       @periodClock.reset(PERIOD_CLOCK_SETTINGS)
     else
-      #Dummy reset
-      @periodClock.reset()
+      @periodClock.start()
   startJam: () ->
     @_clearTimeouts()
     @_pushUndo()

--- a/test/models/game_state-test.coffee
+++ b/test/models/game_state-test.coffee
@@ -63,14 +63,24 @@ describe 'GameState', () ->
           expect(gameState.periodClock.reset).toBeCalledWith
             time: constants.PERIOD_DURATION_IN_MS
             isRunning: true
+        .then (gameState) ->
+          callback
+            type: ActionTypes.START_JAM
+            gameId: gameState.id
+        .tap (gameState) ->
+          expect(gameState.period).toBe 'period 1'
+          expect(gameState.periodClock.start).toBeCalled()
           gameState.period = 'halftime'
-        .tap GameState.save
+          gameState.save()
         .then (gameState) ->
           callback
             type: ActionTypes.START_JAM
             gameId: gameState.id
         .then (gameState) ->
           expect(gameState.period).toBe('period 2')
+          expect(gameState.periodClock.reset).toBeCalledWith
+            time: constants.PERIOD_DURATION_IN_MS
+            isRunning: true
       pit "sets the state to jam", () ->
         gameState.then (gameState) ->
           expect(gameState.state).toBe('jam')


### PR DESCRIPTION
I found a bug in which period clocks were not properly resuming when starting a new jam from a timeout. This bug was likely introduced as part of #92. Test coverage is expanded to cover this scenario.
