### PR TITLE
Edit existing games

### DIFF
--- a/app/scripts/models/game_state.coffee
+++ b/app/scripts/models/game_state.coffee
@@ -159,9 +159,9 @@ class GameState extends Store
           game.redo()
           game.save()
       when ActionTypes.SAVE_GAME
-        @new(action.gameState).then (game) ->
-          game.syncClocks(action.gameState)
-          game.save(true)
+        game = new this(action.gameState)
+        game.syncClocks(action.gameState)
+        game.save(true)
   constructor: (options={}) ->
     super options
     @name = options.name
@@ -177,8 +177,8 @@ class GameState extends Store
     @jamClock = @clockManager.getOrAddClock "jamClock-#{@id}", options.jamClock ? PREGAME_CLOCK_SETTINGS
     @periodClock = @clockManager.getOrAddClock "periodClock-#{@id}", options.periodClock ? PERIOD_CLOCK_SETTINGS
     @timeout = options.timeout ? null
-    @home = options.home
-    @away = options.away
+    @home = new Team(options.home)
+    @away = new Team(options.away)
     @penalties = [
       {code: "A", name: "High Block"},
       {code: "N", name: "Insubordination"},

--- a/app/scripts/models/jam.coffee
+++ b/app/scripts/models/jam.coffee
@@ -65,13 +65,13 @@ class Jam extends Store
     @noPivot = options.noPivot ? false
     @starPass = options.starPass ? false
     @starPassNumber = options.starPassNumber ? 0
-    @pivot = options.pivot
-    @blocker1 = options.blocker1
-    @blocker2 = options.blocker2
-    @blocker3 = options.blocker3
-    @jammer = options.jammer
+    @pivot = new Skater(options.pivot) if options.pivot?
+    @blocker1 = new Skater(options.blocker1) if options.blocker1
+    @blocker2 = new Skater(options.blocker2) if options.blocker2
+    @blocker3 = new Skater(options.blocker3) if options.blocker3
+    @jammer = new Skater(options.jammer) if options.jammer
     @passSequence = seedrandom(@id, state: options.passSequenceState ? true)
-    @passes = options.passes ? [id: functions.uniqueId(8, @passSequence)]
+    @passes = (options.passes ? [id: functions.uniqueId(8, @passSequence)]).map (pass) -> new Pass(pass)
     @passSequenceState = @passSequence.state()
     @lineupStatuses = options.lineupStatuses ? []
   load: () ->

--- a/app/scripts/models/pass.coffee
+++ b/app/scripts/models/pass.coffee
@@ -48,7 +48,7 @@ class Pass extends Store
     @jamId = options.jamId
     @passNumber = options.passNumber ? 1
     @points = options.points ? 0
-    @jammer = options.jammer
+    @jammer = new Skater(options.jammer) if options.jammer?
     @injury = options.injury ? false
     @lead = options.lead ? false
     @lostLead = options.lostLead ? false

--- a/app/scripts/models/team.coffee
+++ b/app/scripts/models/team.coffee
@@ -64,9 +64,9 @@ class Team extends Store
     @hasOfficialReview = options.hasOfficialReview ? true
     @timeouts = options.timeouts ? 3
     @jamSequence = seedrandom(@id, state: options.jamSequenceState ? true)
-    @jams = options.jams ? [id: functions.uniqueId(8, @jamSequence)]
+    @jams = (options.jams ? [id: functions.uniqueId(8, @jamSequence)]).map (jam) -> new Jam(jam)
     @jamSequenceState = @jamSequence.state()
-    @skaters = options.skaters ? []
+    @skaters = (options.skaters ? []).map (skater) -> new Skater(skater)
     @penaltyBoxStates = options.penaltyBoxStates ? []
     @clockManager = new ClockManager()
     for boxState in @penaltyBoxStates


### PR DESCRIPTION
descendants of games (teams, skaters, etc) were being reloaded from store before being saved (thus clobbering changes). This PR fixes that, allowing rosters, team info, etc to be edited from game setup on an existing game.
