### PR TITLE
indicate penalties being sat with dots

### DIFF
--- a/app/scripts/components/penalty_tracker/edit_penalty_panel.cjsx
+++ b/app/scripts/components/penalty_tracker/edit_penalty_panel.cjsx
@@ -16,8 +16,6 @@ module.exports = React.createClass
   clearPenalty: () ->
     @closePanel()
     @props.clearPenalty()
-  closePanel: () ->
-    $(@getDOMNode()).collapse('hide')
   componentDidMount: () ->
     $dom = $(@getDOMNode())
     $dom.on 'show.bs.collapse', (evt) =>
@@ -31,6 +29,9 @@ module.exports = React.createClass
       'edit-penalty collapse': true
     classArgs["penalty-#{@props.penaltyNumber % 7}"] = true
     containerClass = cx classArgs
+    satClass = cx
+      'bt-btn': true
+      'btn-primary': @props.skaterPenalty.sat
     <div className={containerClass} id={@props.id}>
       <div className='row gutters-xs'>
         <div className='col-xs-1'>
@@ -58,8 +59,8 @@ module.exports = React.createClass
           </div>
         </div>
         <div className='col-xs-1'>
-          <button className='bt-btn btn-primary' onClick={@closePanel}>
-            <span className='glyphicon glyphicon-remove'></span>
+          <button className={satClass} onClick={@props.toggleSat}>
+            <span>&middot;</span>
           </button>
         </div>
       </div>

--- a/app/scripts/components/penalty_tracker/penalty_indicator.cjsx
+++ b/app/scripts/components/penalty_tracker/penalty_indicator.cjsx
@@ -18,4 +18,5 @@ module.exports = React.createClass
       'box-danger': @props.skaterPenalty? and @props.penaltyNumber >= 7
     <div className={containerClass} style={@props.teamStyle if @props.skaterPenalty? and @props.penaltyNumber < 6}>
       <strong>{@displayContent()}</strong>
+      {<span className='dot'>&middot;</span> if @props.skaterPenalty?.sat}
     </div>

--- a/app/scripts/components/penalty_tracker/skater_penalties.cjsx
+++ b/app/scripts/components/penalty_tracker/skater_penalties.cjsx
@@ -32,6 +32,13 @@ module.exports = React.createClass
       type: ActionTypes.CLEAR_PENALTY
       skaterId: @props.skater.id
       skaterPenaltyIndex: skaterPenaltyIndex
+  toggleSat: (skaterPenaltyIndex) ->
+    AppDispatcher.dispatchAndEmit
+      type: ActionTypes.UPDATE_PENALTY
+      skaterId: @props.skater.id
+      skaterPenaltyIndex: skaterPenaltyIndex
+      opts:
+        sat: not @props.skater.penalties[skaterPenaltyIndex].sat
   getPenaltyId: (penaltyIndex) ->
     "edit-penalty-#{@props.skater.id}-#{penaltyIndex}"
   render: () ->
@@ -78,6 +85,7 @@ module.exports = React.createClass
               incrementJamNumber={@incrementJamNumber.bind(this, penaltyIndex)}
               decrementJamNumber={@decrementJamNumber.bind(this, penaltyIndex)}
               clearPenalty={@clearPenalty.bind(this, penaltyIndex)}
+              toggleSat={@toggleSat.bind(this, penaltyIndex)}
               onOpen={@props.editHandler.bind(null, penaltyIndex)}
               onClose={@props.editHandler.bind(null, null)}/>
           , this}
@@ -107,6 +115,7 @@ module.exports = React.createClass
               incrementJamNumber={@incrementJamNumber.bind(this, penaltyIndex + 7)}
               decrementJamNumber={@decrementJamNumber.bind(this, penaltyIndex + 7)}
               clearPenalty={@clearPenalty.bind(this, penaltyIndex + 7)}
+              toggleSat={@toggleSat.bind(this, penaltyIndex + 7)}
               onOpen={@props.editHandler.bind(null, penaltyIndex + 7)}
               onClose={@props.editHandler.bind(null, null)}/>
           , this}

--- a/app/scripts/models/skater.coffee
+++ b/app/scripts/models/skater.coffee
@@ -28,6 +28,7 @@ class Skater extends Store
     @penalties.push
       penalty: penalty
       jamNumber: jamNumber
+      sat: false
   clearPenalty: (skaterPenaltyIndex) ->
     @penalties.splice(skaterPenaltyIndex, 1)
   updatePenalty: (skaterPenaltyIndex, opts={}) ->

--- a/app/styles/_penalty-tracker.scss
+++ b/app/styles/_penalty-tracker.scss
@@ -1,7 +1,14 @@
 .penalty-tracker, .penalty-whiteboard {
   .penalty-indicator {
+    position: relative;
     white-space: nowrap;
     color: $gray;
+    .dot {
+      position: absolute;
+      bottom: 0;
+      left: 50%;
+      transform: translateX(-50%);
+    }
   }
   .penalty-alert {
     @extend .penalty-indicator;

--- a/test/models/skater-test.coffee
+++ b/test/models/skater-test.coffee
@@ -33,6 +33,7 @@ describe 'Skater', () ->
           expect(skater.penalties.length).toBe(1)
           expect(skater.penalties[0]).toEqual
             jamNumber: 1
+            sat: false
             penalty: {foo: 'bar'}
       pit "updates a penalty", () ->
         skater.then (skater) ->
@@ -44,11 +45,13 @@ describe 'Skater', () ->
               jamNumber: 2
               penalty:
                 foo: 'baz'
+              sat: true
         .then (skater) ->
           expect(skater.penalties[0]).toEqual
             jamNumber: 2
             penalty:
               foo: 'baz'
+            sat: true
       pit "clears a penalty", () ->
         skater.then (skater) ->
           callback


### PR DESCRIPTION
PT can dot penalties. This is unrelated to the PBT, and bypasses the need for tighter integration between PT and PBT data. The X button from the penalty edit panel has been replace with a dot button. When selected, it places a dot under the penalty code for the corresponding penalty wherever it is shown (PT summary, IWB, etc)
