### PR TITLE
load skater prototype on PBT seats

### DIFF
--- a/app/scripts/models/box_entry.coffee
+++ b/app/scripts/models/box_entry.coffee
@@ -51,6 +51,11 @@ class BoxEntry extends Store
     @clock = @_clockManager.getOrAddClock(@id, options.clock ? PENALTY_CLOCK_SETTINGS)
     @dirty = options.dirty ? false
     @sort = options.sort ? 0
+  load: () ->
+    if @skater
+      Skater.new(@skater).then (skater) =>
+        @skater = skater
+      .return(this)
   toggleLeftEarly: () ->
     @leftEarly = not @leftEarly
   toggleServed: () ->


### PR DESCRIPTION
The skater property of box entries was just an object with skater data, and did not have the Skater prototype applied to it. This PR fixes that, allowing Skater prototype methods to be called on the skater attribute of a box entry.
