### PR TITLE
Bump to 0.0.23

### DIFF
--- a/bin/bouttime-server
+++ b/bin/bouttime-server
@@ -3,7 +3,7 @@ server = require ('../dist/server');
 program = require ('commander');
 
 program
-  .version('0.0.22')
+  .version('0.0.23')
   .option('-p, --port [port]', 'Specify a port to listen on')
   .parse(process.argv)
 

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "bouttime",
-  "version": "0.0.22",
+  "version": "0.0.23",
   "dependencies": {
     "jquery": "~2.1.4",
     "bootstrap-sass": "~3.3.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wftda-bouttime",
-  "version": "0.0.22",
+  "version": "0.0.23",
   "author": "WFTDA",
   "description": "WFTDA BoutTime App",
   "license": "SEE LICENSE IN LICENSE",

--- a/setup.sh
+++ b/setup.sh
@@ -3,7 +3,7 @@
 set -e -o pipefail
 
 echo "installing bower and gulp globally"
-npm install bower gulp
+npm install -g bower gulp
 
 echo "installing NPM dependencies"
 npm install


### PR DESCRIPTION
Bring version up to incorporate cleanups for first public alpha release

Changes proposed in this PR:
- Just carrying a slight fix to setup.sh that slipped by, bower and gulp must be global

Code review: @WFTDA/bouttime, @WFTDA/code-monkeys
