### PR TITLE
Remove references to global installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,19 +23,8 @@ We recommend [installing for local development](#development)
 
 ---
 
-
-    $ npm install -g wftda-bouttime
-
-Once it is installed you can run it using the following command:
-
-    $ bouttime-server
-
 With the BoutTime server running in the background, open a browser to
 `http://localhost:3000` to use the app.
-
-To update to a newer version, use this command:
-
-    $ npm update -g wftda-bouttime
 
 **Note:** At this present moment, the software is considered alpha so we are
 discouraging regular installations in favor of local development installs.


### PR DESCRIPTION
Code review: @WFTDA/bouttime, @WFTDA/code-monkeys

The NPM-packaged artifact is not currently a viable method for
installation yet, and have tripped up users despite the warning.

Remove these references until a time the package is stable enough to
reintroduce this install method.

Refs #138 [ci skip]

Signed-off-by: Mike Fiedler <miketheman@gmail.com>