### PR TITLE
Update license

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM node:0.10
 
-RUN mkdir -p /opt/wftda/bouttime
-WORKDIR /opt/wftda/bouttime
+RUN mkdir -p /opt/bouttime
+WORKDIR /opt/bouttime
 
 RUN echo '{ "allow_root": true }' > /root/.bowerrc
 ADD package.json npm-shrinkwrap.json ./
@@ -14,7 +14,7 @@ COPY ./bin/ ./bin/
 
 RUN npm run build
 
-VOLUME /opt/wftda/bouttime/
+VOLUME /opt/bouttime/
 EXPOSE 3000
 
 CMD ["./bin/bouttime-server"]

--- a/LICENSE
+++ b/LICENSE
@@ -1,58 +1,13 @@
-License for Use, Reproduction, and Distribution of WFTDA's "BoutTime"
+Copyright 2016 Women's Flat Track Derby Association
 
-WFTDA, a 501c3 not-for-profit organization, grants You the right to use BoutTime (the "Work") on the terms and conditions outlined below. The purpose of this license is to allow anyone to download and use BoutTime in connection with roller derby. This license does not allow you to redistribute derivative works based on the Work, or to use the Work commercially. This means that you are not allowed to sell copies of the Work (or derivative works based on the Work), or to package the Work within a product or service for sale, without the written consent of WFTDA.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-1. Definitions.
+    http://www.apache.org/licenses/LICENSE-2.0
 
-"License" means the terms and conditions for use, reproduction, and distribution of the Work, as defined in this document.
-
-"Licensor" means Women's Flat Track Derby Association, the copyright owner, or an entity authorized by the copyright owner, that is granting the License.
-
-"Legal Entity" means the union of the acting entity and all other entities that control, are controlled by, or are under common control with that entity. For the purposes of this definition, "control" means (i) the power, direct or indirect, to cause the direction or management of such entity, whether by contract or otherwise, or (ii) ownership of fifty percent (50%) or more of the outstanding shares, or (iii) beneficial ownership of such entity.
-
-"You" (or "Your") means an individual or Legal Entity exercising permissions granted by this License.
-
-"Source" form means the preferred form for making modifications, including but not limited to software source code, documentation source, and configuration files.
-
-"Object" form means any form resulting from mechanical transformation or translation of a Source form, including but not limited to compiled object code, generated documentation, and conversions to other media types.
-
-"Work" means the work of authorship, in any form (including but not limited to Source or Object form), made available under this License. The copyright notice (and identification of the rightsholder) is included in or attached to the Work (an example is provided in the Appendix below).
-
-"Derivative Works" means any work, in any form (including but not limited to Source or Object form), that is based on, derived from, or includes part or all of the Work, and for which the editorial revisions, annotations, elaborations, or other modifications represent, as a whole, an original work of authorship. For the purposes of this License, Derivative Works will not include works that remain separable from, or merely link (or bind by name) to the interfaces of the Work (and Derivative Works thereof).
-
-"Contribution" means any work of authorship, including the original version of the Work and any modifications or additions to that Work (or Derivative Works thereof), that is intentionally submitted to Licensor by a Contributor for inclusion in the Work by the copyright owner or by an individual or Legal Entity authorized to submit on behalf of the copyright owner. For the purposes of this definition, "submitted" means any form of electronic, verbal, or written communication sent to the Licensor or its representatives, including but not limited to communication on electronic mailing lists, source code control systems, and issue tracking systems that are managed by, or on behalf of, the Licensor for the purpose of discussing and improving the Work. "Submitted" does not include communication that is conspicuously marked or otherwise designated in writing by the copyright owner as "Not a Contribution."
-
-"Contributor" means Licensor and any individual or Legal Entity on behalf of whom a Contribution has been received by Licensor, whose Contribution has been subsequently incorporated into the Work.
-
-2. Grant of Copyright License. Subject to the terms and conditions of this License:
-(a) Licensor grants to You a worldwide, non-exclusive, no-charge, royalty-free license that allows you to reproduce, publicly display, publicly perform, sublicense, and distribute the Work (including Contributions) in Source or Object form;
-(b) each Contributor hereby grants to Licensor a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable copyright license to reproduce, prepare Derivative Works of, publicly display, publicly perform, sublicense, and distribute Contributor's Contributions, and to incorporate them into the Work (and Derivative Works) in Source or Object form.
-
-3. Grant of Patent License. Subject to the terms and conditions of this License:
-(a) Licensor grants to You a worldwide, non-exclusive, no-charge, royalty-free license to reproduce, publicly display, publicly perform, sublicense, and distribute the Work (including Contributions), where such license applies only to those patent claims licensable by Licensor and such Contributor, that are necessarily infringed by their Contribution(s) alone or by combination of their Contribution(s) with the Work to which such Contribution(s) was submitted;
-(b) each Contributor hereby grants to Licensor a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable (except as stated in this section) patent license to make, have made, use, offer to sell, sell, import, and otherwise transfer Contributor's Contributions, where such license applies only to those patent claims licensable by such Contributor that are necessarily infringed by their Contribution(s) alone or by combination of their Contribution(s) with the Work to which such Contribution(s) was submitted. If You institute patent litigation (or threaten to institute patent litigation) against any entity (including a cross-claim or counterclaim in a lawsuit) alleging that the Work or a Contribution incorporated into the Work constitutes direct or contributory patent infringement, then any patent licenses granted to You under this License for that Work will terminate as of the date such litigation is filed, or is threatened (in writing) to be filed.
-
-4. Redistribution. You may reproduce and distribute copies of the Work in any medium, and in Source or Object form, provided that You meet the following conditions:
-(a) You must give any recipients of the Work a copy of this License, and any modified versions of the Work must be subject to the terms of this License;
-(b) You must cause any modified versions of the Work to carry prominent notices stating that You made modifications to the Work, and highlight the modifications;
-(c) You must retain, in the Source form of any Work that You distribute (including modified versions), all copyright, patent, trademark, and attribution notices from the Source form of the Work, and WFTDA's mission, including the following:
-- © 2006-2017 WFTDA; WFTDA and its logos are registered trademarks of WFTDA. The Women's Flat Track Derby Association (WFTDA) promotes and fosters the sport of women's flat track roller derby by facilitating the development of athletic ability, sportswomanship, and goodwill among leagues and competitors; and
-(d) Any Works that You distribute must include a readable copy of the attribution/credit notices, in at least one of the following places: 
-- within the Source form or documentation, or 
-- within a display generated by the Works, if and wherever such attribution/credit notices normally appear.
-(e) The contents of any NOTICE file are for informational purposes only and do not modify this License. You may add Your own attribution notices within Works that You modify, alongside or as an addendum to the NOTICE text from the Work, provided that such additional attribution notices cannot be construed as modifying the License, and Your use, reproduction, and distribution of the Work otherwise complies with the conditions stated in this License.
-
-5. Submission of Contributions. Unless You explicitly state otherwise, any Contribution intentionally submitted for inclusion in the Work by You to the Licensor will be under the terms and conditions of this License, without any additional terms or conditions. Notwithstanding the above, nothing herein will supersede or modify the terms of any separate license agreement you may have executed with Licensor regarding such Contributions.
-
-6. Trademarks. This License does not grant permission to use the trade names, trademarks, service marks, or product names of the Licensor, except as required for reasonable and customary use in describing the origin of the Work and reproducing the content of the NOTICE file.
-
-7. Disclaimer of Warranty. Unless required by applicable law or agreed to in writing, Licensor provides the Work (and each Contributor provides its Contributions) on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied, including, without limitation, any warranties or conditions of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE. You are solely responsible for determining the appropriateness of using or redistributing the Work and assume any risks associated with Your exercise of permissions under this License.
-
-8. Limitation of Liability. In no event and under no legal theory, whether in tort (including negligence), contract, or otherwise, unless required by applicable law (such as deliberate and grossly negligent acts) or agreed to in writing, will Licensor or any Contributor be liable to You for damages, including any direct, indirect, special, incidental, or consequential damages of any character arising as a result of this License or out of the use or inability to use the Work (including but not limited to damages for loss of goodwill, work stoppage, computer failure or malfunction, or any and all other commercial damages or losses), even if Licensor or such Contributor has been advised of the possibility of such damages.
-
-9. Accepting Warranty or Additional Liability. While redistributing the Work (or, with WFTDA's consent, Derivative Works thereof), You may choose to offer support, warranty, indemnity, or other liability obligations and/or rights consistent with this License. However, in accepting such obligations, You may act only on Your own behalf and on Your sole responsibility, not on behalf of Licensor or any other Contributor, and only if You agree to indemnify, defend, and hold Licensor and each Contributor harmless for any liability incurred by, or claims asserted against, Licensor or such Contributor by reason of your accepting any such warranty or additional liability.
-
-BoutTime copyright: © 2016-2017 Women's Flat Track Derby Association
-You may not use BoutTime except in compliance with the License. For additional permissions, contact: tech@wftda.com
-
-Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![CircleCI](https://circleci.com/gh/WFTDA/bouttime.svg?style=svg&circle-token=9b5d2312f6063d633b844c97c873653c13b26513)](https://circleci.com/gh/WFTDA/bouttime)
-[![Code Climate](https://codeclimate.com/github/WFTDA/bouttime/badges/gpa.svg)](https://codeclimate.com/github/WFTDA/bouttime)
+[![Code Climate](https://codeclimate.com/github/DerbyBoutTime/bouttime/badges/gpa.svg)](https://codeclimate.com/github/WFTDA/bouttime)
 
 # Prerequisites
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,5 +6,5 @@ services:
     ports:
       - 3000:3000
     volumes:
-      - ./app/:/opt/wftda/bouttime/app/
+      - ./app/:/opt/bouttime/app/
     command: npm run watch

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
   "name": "wftda-bouttime",
   "version": "0.0.23",
-  "author": "WFTDA",
-  "description": "WFTDA BoutTime App",
-  "license": "SEE LICENSE IN LICENSE",
+  "author": "Derby BoutTime",
+  "description": "BoutTime App",
+  "license": "Apache 2.0",
   "main": "dist/server.js",
   "bin": {
     "bouttime-server": "bin/bouttime-server"
@@ -16,12 +16,12 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/wftda/bouttime.git"
+    "url": "https://github.com/DerbyBoutTime/bouttime.git"
   },
   "bugs": {
-    "url": "https://github.com/wftda/bouttime/issues"
+    "url": "https://github.com/DerbyBoutTime/bouttime/issues"
   },
-  "homepage": "https://github.com/wftda/bouttime",
+  "homepage": "https://github.com/DerbyBoutTime/bouttime",
   "dependencies": {
     "bluebird": "2.9.30",
     "commander": "2.9.0",


### PR DESCRIPTION
The repo has been moved out of the WFTDA organization and into a new community home and the modified license will change to an unmodified Apache 2.0 license.

- Need to followup on the npm repo

Fixes #140.